### PR TITLE
Stop verifying memo program id using string comparison

### DIFF
--- a/programs/open_creator_protocol/Cargo.toml
+++ b/programs/open_creator_protocol/Cargo.toml
@@ -27,3 +27,4 @@ serde_json = "1.0.88"
 solana-program = "^1.9.28"
 spl-associated-token-account = { version = "~1.0.5", features = ["no-entrypoint"] }
 spl-token = { version = "^3.3.0", features = ["no-entrypoint"] }
+spl-memo = { version = "3.0.1", features = ["no-entrypoint"] }

--- a/programs/open_creator_protocol/src/action.rs
+++ b/programs/open_creator_protocol/src/action.rs
@@ -28,7 +28,7 @@ pub struct ActionCtx {
 
 impl ActionCtx {
     fn parse_memo(&mut self, ix: Instruction) {
-        if ix.program_id.to_string() != "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr" {
+        if ix.program_id != spl_memo::id() {
             return;
         }
         if ix.accounts.is_empty() {


### PR DESCRIPTION
Serializing a `Pubkey` to `String` costs 10K compute units, and we do it for every instruction. Save some compute by stopping this.