### PR TITLE
Remove the locked_by == delegate constraint in lock

### DIFF
--- a/programs/open_creator_protocol/Cargo.toml
+++ b/programs/open_creator_protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open_creator_protocol"
-version = "0.3.0"
+version = "0.3.1"
 description = "Open Creator Protocol is an open protocol for creators to build utilities and policy engine for their tokens"
 edition = "2021"
 license = "Apache-2.0"

--- a/programs/open_creator_protocol/src/instructions/nft_proxy/lock.rs
+++ b/programs/open_creator_protocol/src/instructions/nft_proxy/lock.rs
@@ -6,7 +6,6 @@ use anchor_lang::solana_program::sysvar;
 use anchor_spl::metadata::MetadataAccount;
 use anchor_spl::token::Mint;
 use anchor_spl::token::TokenAccount;
-use solana_program::program_option::COption;
 
 #[derive(Accounts)]
 pub struct LockCtx<'info> {
@@ -29,7 +28,6 @@ pub struct LockCtx<'info> {
     from: Signer<'info>,
     #[account(
         constraint = from_account.owner == from.key() && from_account.amount == 1 @ OCPErrorCode::InvalidTokenAccount,
-        constraint = from_account.delegate == COption::Some(to.key()) @ OCPErrorCode::InvalidTokenAccount,
     )]
     from_account: Box<Account<'info, TokenAccount>>,
     /// CHECK: Account is not read from

--- a/sdk/idl/open_creator_protocol.json
+++ b/sdk/idl/open_creator_protocol.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "0.3.1",
   "name": "open_creator_protocol",
   "instructions": [
     {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magiceden-oss/open_creator_protocol",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "SDK for open_creator_protocol",
   "scripts": {
     "build": "tsc"


### PR DESCRIPTION
In order to lock a token, it actually shouldn't require that the locked_by is the same as the approved delegate